### PR TITLE
Infrastructure

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          cache: 'pip'
 
       - name: update submodules
         id: update_submodules


### PR DESCRIPTION
Solves the following error: `Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip`