### PR TITLE
ci: reset offset to single day

### DIFF
--- a/.github/workflows/update-table.yml
+++ b/.github/workflows/update-table.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: find date offset
         id: date_offset
-        run: echo "date_offset=$(date -d '10 days ago' -I)" >> "$GITHUB_OUTPUT"
+        run: echo "date_offset=$(date -d '1 days ago' -I)" >> "$GITHUB_OUTPUT"
 
       - name: retrieve changed files
         uses: tj-actions/changed-files@v46


### PR DESCRIPTION
As long as the Github Action is not disabled, it will correctly pick the changes done during the day.