### PR TITLE
Improvements in `update-table.yml` 

### DIFF
--- a/.github/workflows/scripts/action.py
+++ b/.github/workflows/scripts/action.py
@@ -1,0 +1,17 @@
+from enum import Enum, unique
+
+
+@unique
+class Action(str, Enum):
+    ADD = "add"
+    UPDATE = "update"
+    REMOVE = "remove"
+    UNDEFINED = "undefined"
+
+    @classmethod
+    def _missing_(cls, value: str):
+        value = value.lower()
+        for member in cls:
+            if member.value in value:
+                return member
+        return Action.UNDEFINED

--- a/.github/workflows/scripts/solution.py
+++ b/.github/workflows/scripts/solution.py
@@ -15,7 +15,14 @@ METADATA = {
 
 class Solution:
     def __init__(self, file_path: str, action_type: Action, server_url: str, repo: str):
-        timestamp, commit, sha = Solution.find_metadata(file_path)
+        self.file_path = file_path
+        metadata = Solution.find_metadata(file_path)
+
+        if not metadata:
+            self.action = Action.UNDEFINED
+            return
+
+        timestamp, commit, sha = metadata
         self.problem_name, *_ = re.findall(QUOTATION_TEXT, commit)
         self.timestamp = int(timestamp)
         self.action = action_type
@@ -42,8 +49,4 @@ class Solution:
         return completed_process.stdout.splitlines()
 
     def __str__(self):
-        match self.action:
-            case Action.UNDEFINED:
-                return f"{self.action}"
-            case _:
-                return f"solution: {self.action} github_url: {self.github_url} host_url: {self.host_url}"
+        return " ".join(f"{key}: {value}" for key, value in vars(self).items())

--- a/.github/workflows/scripts/solution.py
+++ b/.github/workflows/scripts/solution.py
@@ -1,0 +1,49 @@
+import re
+import subprocess
+from action import Action
+
+QUOTATION_TEXT = r"'([^']*)'"
+
+ILLEGAL_SYMBOLS = r"[^a-zA-Z0-9- ]"
+
+METADATA = {
+    "author_time": "at",
+    "commit_message": "B",
+    "commit_hash": "H"
+}
+
+
+class Solution:
+    def __init__(self, file_path: str, action_type: Action, server_url: str, repo: str):
+        timestamp, commit, sha = Solution.find_metadata(file_path)
+        self.problem_name, *_ = re.findall(QUOTATION_TEXT, commit)
+        self.timestamp = int(timestamp)
+        self.action = action_type
+        self.sha = sha
+
+        dashed_name = re.sub(ILLEGAL_SYMBOLS, "", self.problem_name).replace(" ", "-").lower()
+        commit_metadata = re.sub(QUOTATION_TEXT, "", commit).lower()
+        emoji = "arrows_counterclockwise" if 'recursive' in commit_metadata else "arrow_right_hook"
+        url = f"https://{'leetcode.com/problems' if 'leetcode' in commit_metadata else 'hackerrank.com/challenges'}"
+
+        self.github_url = f'[:{emoji}:]({server_url}/{repo}/blob/master/{file_path})'
+        self.host_url = f'[{self.problem_name}]({url}/{dashed_name})'
+
+    @staticmethod
+    def find_metadata(path: str) -> list[str]:
+        delimiter = len(METADATA)
+        options = "%n".join("%" + v for v in METADATA.values())
+
+        completed_process = subprocess.run(
+            args=f'git log --pretty=format:"{options}" --follow --grep="^solution" -- {path} | head -n {delimiter}',
+            text=True, check=True, shell=True, stdout=subprocess.PIPE
+        )
+
+        return completed_process.stdout.splitlines()
+
+    def __str__(self):
+        match self.action:
+            case Action.UNDEFINED:
+                return f"{self.action}"
+            case _:
+                return f"solution: {self.action} github_url: {self.github_url} host_url: {self.host_url}"

--- a/.github/workflows/scripts/update_table.py
+++ b/.github/workflows/scripts/update_table.py
@@ -1,18 +1,8 @@
 import os
-import re
-import subprocess
 import sys
-from enum import Enum, unique
-
+from action import Action
+from solution import Solution
 import pandas as pd
-
-QUOTATION_TEXT, ILLEGAL_SYMBOLS = r"'([^']*)'", r"[^a-zA-Z0-9- ]"
-
-METADATA = {
-    "author_time": "at",
-    "commit_message": "B",
-    "commit_hash": "H"
-}
 
 ADDED_FILES, CHANGED_FILES, REMOVED_FILES = [
     os.getenv(env).split() for env in ("added_files", "changed_files", "removed_files")
@@ -22,69 +12,16 @@ REPOSITORY, SERVER_URL, README, DATAFRAME, HEADER = [
     os.getenv(env) for env in ("repository", "server_url", "readme", "dataframe", "header")
 ]
 
+removed_solutions = [Solution(file, Action.REMOVE, SERVER_URL, REPOSITORY) for file in REMOVED_FILES]
+updated_solutions = [Solution(file, Action.UPDATE, SERVER_URL, REPOSITORY) for file in CHANGED_FILES]
+added_solutions = [Solution(file, Action.ADD, SERVER_URL, REPOSITORY) for file in ADDED_FILES]
 
-@unique
-class Action(str, Enum):
-    ADD = "add"
-    UPDATE = "update"
-    REMOVE = "remove"
-    UNDEFINED = "undefined"
-
-    @classmethod
-    def _missing_(cls, value: str):
-        value = value.lower()
-        for member in cls:
-            if member.value in value:
-                return member
-        return Action.UNDEFINED
-
-
-class Solution:
-    def __init__(self, file_path: str, action_type: Action):
-        timestamp, commit, sha = Solution.find_metadata(file_path)
-        self.problem_name, *_ = re.findall(QUOTATION_TEXT, commit)
-        self.timestamp = int(timestamp)
-        self.action = action_type
-        self.sha = sha
-
-        dashed_name = re.sub(ILLEGAL_SYMBOLS, "", self.problem_name).replace(" ", "-").lower()
-        commit_metadata = re.sub(QUOTATION_TEXT, "", commit).lower()
-        emoji = "arrows_counterclockwise" if 'recursive' in commit_metadata else "arrow_right_hook"
-        url = f"https://{'leetcode.com/problems' if 'leetcode' in commit_metadata else 'hackerrank.com/challenges'}"
-
-        self.github_url = f'[:{emoji}:]({SERVER_URL}/{REPOSITORY}/blob/master/{file_path})'
-        self.host_url = f'[{self.problem_name}]({url}/{dashed_name})'
-
-    @staticmethod
-    def find_metadata(path: str) -> list[str]:
-        delimiter = len(METADATA)
-        options = "%n".join("%" + v for v in METADATA.values())
-
-        completed_process = subprocess.run(
-            args=f'git log --pretty=format:"{options}" --follow --grep="^solution" -- {path} | head -n {delimiter}',
-            text=True, check=True, shell=True, stdout=subprocess.PIPE
-        )
-
-        return completed_process.stdout.splitlines()
-
-    def __str__(self):
-        match self.action:
-            case Action.UNDEFINED:
-                return f"{self.action}"
-            case _:
-                return f"solution: {solution.action} github_url: {self.github_url} host_url: {self.host_url}"
-
-
-removed_solutions = [Solution(file_path=file, action_type=Action.REMOVE) for file in REMOVED_FILES]
-updated_solutions = [Solution(file_path=file, action_type=Action.UPDATE) for file in CHANGED_FILES]
-added_solutions = [Solution(file_path=file, action_type=Action.ADD) for file in ADDED_FILES]
+solutions = sorted(removed_solutions + updated_solutions + added_solutions, key=lambda x: x.timestamp)
 
 df = pd.read_csv(DATAFRAME)
 name_col, lang_col = df.columns
 df = df.assign(lang_col=df[lang_col].str.split(' '))
 df = df.explode(lang_col)
-
-solutions = sorted(removed_solutions + updated_solutions + added_solutions, key=lambda x: x.timestamp)
 mod_df = df
 
 for solution in solutions:

--- a/.github/workflows/update-table.yml
+++ b/.github/workflows/update-table.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: find date offset
         id: date_offset
-        run: echo "date_offset=$(date -d '1 days ago' -I)" >> "$GITHUB_OUTPUT"
+        run: echo "date_offset=$(date -d '7 days ago' -I)" >> "$GITHUB_OUTPUT"
 
       - name: retrieve changed files
         uses: tj-actions/changed-files@v46
@@ -58,7 +58,7 @@ jobs:
           since: ${{ steps.date_offset.outputs.date_offset }}
           files_ignore: ${{ inputs.file-ignore }}
           files: ${{ inputs.path-filter }}
-          fetch_depth: "50"
+          fetch_depth: "100"
           path: source-code
           separator: " "
 


### PR DESCRIPTION
Diffing with the changes from the day before doesn't work as expected because `tj-actions/changed-files` is not picking the  first commit of that day.
To solve this problem, I have increased the size of the window to `7` days; the `github_action` now filters out duplicate solutions (unless the commit message is an `update` in which case it will still write to the dataframe).  