### PR TITLE
fix(github-actions): remove special characters

### DIFF
--- a/.github/workflows/scripts/merge_table.py
+++ b/.github/workflows/scripts/merge_table.py
@@ -41,8 +41,7 @@ if not mod_df.equals(cached_df):
             text=True, check=True, shell=True, stdout=subprocess.PIPE
         )
         commit_sha = completed_process.stdout.strip()
-        url = f"{SERVER_URL}/{ACTOR}/{submodule}/commit/{commit_sha}"
-        details.append(url)
+        details.append(commit_sha)
 
     with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
         noun = "change" if len(details) == 1 else "changes"

--- a/.github/workflows/scripts/update_submodules.py
+++ b/.github/workflows/scripts/update_submodules.py
@@ -16,9 +16,7 @@ for metadata in completed_process.stdout.splitlines():
 
     commit_sha, submodule = metadata.split()
     commit_sha = commit_sha.replace('+', '')
-    language = submodule.replace(f"{SUBMODULE_PREFIX}-", "")
-    url = f"{SERVER_URL}/{ACTOR}/{submodule}/commit/{commit_sha}"
-    details.append(url)
+    details.append(commit_sha)
 
 with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
     noun = "submodule" if len(details) == 1 else "submodules"


### PR DESCRIPTION
Looks like `GITHUB_OUTPUT` gets tripped by multi-line commits with URLs (not sure why). 
A workaround might be encoding/decoding in base64 but for now I will just keep referring to the `commit_sha`.